### PR TITLE
Fix `codex mcp add`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ claude mcp add apple-docs -- npx apple-doc-mcp-server@latest
 
 OpenAI Codex:
 ```bash
-codex mcp add apple-doc-mcp -- npx @apple-doc-mcp-server@latest 
+codex mcp add apple-doc-mcp -- npx apple-doc-mcp-server@latest 
 ```
 
 Or using node with the built file:


### PR DESCRIPTION
Was previously getting this error:

⚠ MCP client for `apple-doc-mcp` failed to start: MCP startup failed: handshaking with MCP server failed: connection
  closed: initialize response

⚠ MCP startup incomplete (failed: apple-doc-mcp)

Removing the `@` mentioned [here](https://github.com/MightyDillah/apple-doc-mcp/issues/18#issuecomment-3612918367) fixed the issue for me in codex-cli 0.80.0